### PR TITLE
Exclude relationships with external target

### DIFF
--- a/src/helper/content-tracker.ts
+++ b/src/helper/content-tracker.ts
@@ -246,14 +246,17 @@ export class ContentTracker {
 
           if (rId === addTarget.rId) {
             const target = element.getAttribute('Target');
+            const targetMode = element.getAttribute('TargetMode');
             const fileInfo = FileHelper.getFileInfo(target);
 
-            rels.push({
-              file: target,
-              filename: fileInfo.base,
-              rId: rId,
-              type: element.getAttribute('Type'),
-            });
+            if (targetMode !== 'External') {
+              rels.push({
+                file: target,
+                filename: fileInfo.base,
+                rId: rId,
+                type: element.getAttribute('Type'),
+              });
+            }
           }
         },
       );

--- a/src/helper/xml-relationship-helper.ts
+++ b/src/helper/xml-relationship-helper.ts
@@ -132,9 +132,13 @@ export class XmlRelationshipHelper {
   ) {
     for (const xmlTarget of this.xmlTargets) {
       const targetFile = xmlTarget.getAttribute('Target');
+      const targetMode = xmlTarget.getAttribute('TargetMode');
       const targetPath = targetFile.replace('../', 'ppt/');
 
-      if (this.archive.fileExists(targetPath) === false) {
+      if (
+        targetMode !== 'External' &&
+        this.archive.fileExists(targetPath) === false
+      ) {
         if (check) {
           console.error(
             'Related content from ' +


### PR DESCRIPTION
External URL of hyperlinks are referenced as TargetMode="External" in the relationships file.
It is mandatory to exclude them, since they are not actual files on disk.