### PR TITLE
Extended Charts do not get recognized as a "chart" type

### DIFF
--- a/__tests__/modify-chart-waterfall.test.ts
+++ b/__tests__/modify-chart-waterfall.test.ts
@@ -1,0 +1,74 @@
+import Automizer, { modify } from '../src/index';
+import { ChartData } from '../src/types/chart-types';
+
+const data = {
+  series: [{ label: 'series 1' }, { label: 'series 2' }, { label: 'series 3' }],
+  categories: [
+    { label: 'cat 2-1', values: [50, 50, 20] },
+    { label: 'cat 2-2', values: [14, 50, 20] },
+    { label: 'cat 2-3', values: [15, 50, 20] },
+    { label: 'cat 2-4', values: [26, 50, 20] },
+  ],
+};
+
+test('Add slide with charts and modify waterfall data and total column.', async () => {
+  const automizer = new Automizer({
+    templateDir: `${__dirname}/pptx-templates`,
+    outputDir: `${__dirname}/pptx-output`,
+  });
+
+  const pres = automizer
+    .loadRoot(`RootTemplate.pptx`)
+    .load(`ChartWaterfall.pptx`, 'charts');
+
+  const result = await pres
+    .addSlide('charts', 1, (slide) => {
+      slide.modifyElement('Waterfall 1', [
+        modify.setWaterFallColumnTotalToLast(), //set total to last
+      ]);
+    })
+    .addSlide('charts', 1, (slide) => { //Modify Data
+      slide.modifyElement('Waterfall 1', [
+      modify.setExtendedChartData({
+        series: [{ label: 'series 1' }],
+        categories: [
+          { label: 'cat 2-1', values: [100] },
+          { label: 'cat 2-3', values: [50] },
+          { label: 'cat 2-4', values: [-40] },
+        ],
+      }),
+    ]);
+  })
+    .addSlide('charts', 1, (slide) => { //Modify Data and set Total to middle
+      slide.modifyElement('Waterfall 1', [
+      modify.setExtendedChartData({
+        series: [{ label: 'series 1' }],
+        categories: [
+          { label: 'cat 2-1', values: [100] },
+          { label: 'cat 2-3', values: [50] },
+          { label: 'sub total', values: [150] },
+          { label: 'cat 2-4', values: [-40] }
+        ],
+      }),
+      modify.setWaterFallColumnTotalToLast(2)
+    ]);
+  })
+    .addSlide('charts', 1, (slide) => { //Modify Data and set Total to last
+      slide.modifyElement('Waterfall 1', [
+      modify.setExtendedChartData({
+        series: [{ label: 'series 1' }],
+        categories: [
+          { label: 'cat 2-1', values: [100] },
+          { label: 'cat 2-3', values: [50] },
+          { label: 'sub total', values: [150] },
+          { label: 'cat 2-4', values: [-40] },
+          { label: 'total', values: [330] },
+        ],
+      }),
+      modify.setWaterFallColumnTotalToLast()
+    ]);
+  })
+    .write(`modify-chart-waterfall.test.pptx`);
+
+  expect(result.charts).toBe(8);
+});

--- a/src/helper/modify-chart-helper.ts
+++ b/src/helper/modify-chart-helper.ts
@@ -436,6 +436,36 @@ export default class ModifyChartHelper {
     };
 
   /**
+   * Set a waterfall Total column to last
+   * you may also optionally specify a different index.
+   @param TotalColumnIDX
+   *
+   */
+  static setWaterFallColumnTotalToLast = (TotalColumnIDX?: number): ChartModificationCallback =>
+    (element: XmlElement, chart: XmlDocument): void => {
+
+      const plotArea = chart.getElementsByTagName('cx:plotArea')[0];
+      const subTotals = plotArea?.getElementsByTagName('cx:layoutPr')[0]?.getElementsByTagName('cx:subtotals')[0];
+
+      if (subTotals) {
+        if (!TotalColumnIDX) {
+          const GetTotalPoints = chart.getElementsByTagName('cx:chartData')[0]?.getElementsByTagName('cx:data')[0]?.getElementsByTagName('cx:strDim')[0]?.getElementsByTagName('cx:lvl')[0]?.getAttribute('ptCount');
+          if (GetTotalPoints) {
+            TotalColumnIDX = Number(GetTotalPoints) - 1;
+          }
+        }
+        if (TotalColumnIDX !== undefined) {
+          const stIndexes = Array.from(subTotals.getElementsByTagName('cx:idx'));
+          stIndexes.forEach((sTValue, index) => {
+            ModifyXmlHelper.attribute('val', TotalColumnIDX.toString())(sTValue);
+            if (index > 0) {
+              subTotals.removeChild(sTValue);
+            }
+          });
+        }
+      }
+    };
+  /**
    * Set the title of a chart.
     @param newTitle
    *
@@ -443,7 +473,7 @@ export default class ModifyChartHelper {
     static setChartTitle =
     (newTitle: string): ChartModificationCallback =>
       (element: XmlElement, chart: XmlDocument): void => {
-        if (chart.getElementsByTagName('c:title')[0].getElementsByTagName('a:t')) {
+        if (chart.getElementsByTagName('c:title')[0].getElementsByTagName('a:t')[0]) {
           chart.getElementsByTagName('c:title')[0].getElementsByTagName('a:t')[0].textContent = newTitle;
         }
       };

--- a/src/helper/xml-slide-helper.ts
+++ b/src/helper/xml-slide-helper.ts
@@ -12,6 +12,7 @@ export const nsMain =
 export const mapUriType = {
   'http://schemas.openxmlformats.org/drawingml/2006/table': 'table',
   'http://schemas.openxmlformats.org/drawingml/2006/chart': 'chart',
+  'http://schemas.microsoft.com/office/drawing/2014/chartex': 'chart',
 };
 
 /**

--- a/src/helper/xml-slide-helper.ts
+++ b/src/helper/xml-slide-helper.ts
@@ -12,7 +12,7 @@ export const nsMain =
 export const mapUriType = {
   'http://schemas.openxmlformats.org/drawingml/2006/table': 'table',
   'http://schemas.openxmlformats.org/drawingml/2006/chart': 'chart',
-  'http://schemas.microsoft.com/office/drawing/2014/chartex': 'chart',
+  'http://schemas.microsoft.com/office/drawing/2014/chartex': 'chartEx',
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,6 +73,7 @@ const setPlotArea = ModifyChartHelper.setPlotArea;
 const setLegendPosition = ModifyChartHelper.setLegendPosition;
 const removeChartLegend = ModifyChartHelper.removeChartLegend;
 const minimizeChartLegend = ModifyChartHelper.minimizeChartLegend;
+const setWaterFallColumnTotalToLast = ModifyChartHelper.setWaterFallColumnTotalToLast;
 const setChartTitle = ModifyChartHelper.setChartTitle;
 const setDataLabelAttributes = ModifyChartHelper.setDataLabelAttributes;
 
@@ -135,6 +136,7 @@ export const modify = {
   setLegendPosition,
   removeChartLegend,
   minimizeChartLegend,
+  setWaterFallColumnTotalToLast,
   setChartTitle,
   setDataLabelAttributes,
 };

--- a/src/types/xml-types.ts
+++ b/src/types/xml-types.ts
@@ -54,7 +54,7 @@ export type TemplateSlideInfo = {
   name: string;
 };
 
-export type ElementType = 'sp' | 'chart' | 'table' | 'pic' | 'cxnSp';
+export type ElementType = 'sp' | 'chart' | 'chartEx' | 'table' | 'pic' | 'cxnSp';
 
 export type ElementInfo = {
   name: string;


### PR DESCRIPTION
Waterfall charts for example appear as extended charts namespace.  Need to support those in order to for the type to be correctly set from graphicframe to "chart"

Also add ability to set what column acts as total for a Waterfall Chart