### PR TITLE
fixed issues where a full byte array could be logged to the console.

### DIFF
--- a/src/helper/archive/archive-fs.ts
+++ b/src/helper/archive/archive-fs.ts
@@ -1,7 +1,11 @@
 import Archive from './archive';
 import fs, { promises as fsPromises } from 'fs';
 import JSZip, { InputType } from 'jszip';
-import { ArchiveParams, AutomizerParams } from '../../types/types';
+import {
+  ArchiveParams,
+  AutomizerFile,
+  AutomizerParams,
+} from '../../types/types';
 import IArchive, { ArchivedFile } from '../../interfaces/iarchive';
 import { XmlDocument } from '../../types/xml-types';
 import ArchiveJszip from './archive-jszip';
@@ -26,10 +30,11 @@ export default class ArchiveFs extends Archive implements IArchive {
   workDir: string;
   isActive: boolean;
   isRoot: boolean;
+  filename: string;
 
   constructor(filename: string, params: ArchiveParams) {
     super(filename);
-
+    this.filename = filename;
     this.params = params;
   }
 

--- a/src/helper/archive/archive-jszip.ts
+++ b/src/helper/archive/archive-jszip.ts
@@ -19,7 +19,7 @@ export default class ArchiveJszip extends Archive implements IArchive {
     if (typeof this.filename !== 'object') {
       this.file = await fs.promises.readFile(this.filename);
     } else {
-      this.file = this.filename;
+      this.file = this.filename as Buffer;
     }
     const zip = new JSZip();
     this.archive = await zip.loadAsync(this.file as unknown as InputType);
@@ -56,9 +56,13 @@ export default class ArchiveJszip extends Archive implements IArchive {
     }
 
     if (!this.archive.files[file]) {
-      throw new Error(
-        'Could not find file ' + file + '@' + path.basename(this.filename),
-      );
+      if (typeof this.filename === 'string') {
+        throw new Error(
+          'Could not find file ' + file + '@' + path.basename(this.filename),
+        );
+      } else {
+        throw new Error('Could not find file ' + file);
+      }
     }
 
     return this.archive.files[file].async(type || 'string');

--- a/src/helper/archive/archive.ts
+++ b/src/helper/archive/archive.ts
@@ -1,17 +1,17 @@
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import { ArchivedFile, ArchiveType } from '../../interfaces/iarchive';
 import { XmlDocument } from '../../types/xml-types';
-import { AutomizerParams } from '../../types/types';
+import { AutomizerFile, AutomizerParams } from '../../types/types';
 import JSZip from 'jszip';
 
 export default class Archive {
-  filename: string;
+  filename: AutomizerFile;
   buffer: ArchivedFile[] = [];
   options: JSZip.JSZipGeneratorOptions<'nodebuffer'> = {
     type: 'nodebuffer',
   };
 
-  constructor(filename) {
+  constructor(filename: AutomizerFile) {
     this.filename = filename;
   }
 

--- a/src/helper/xml-relationship-helper.ts
+++ b/src/helper/xml-relationship-helper.ts
@@ -140,12 +140,16 @@ export class XmlRelationshipHelper {
         this.archive.fileExists(targetPath) === false
       ) {
         if (check) {
-          console.error(
-            'Related content from ' +
-              sourceArchive.filename +
-              ' not found: ' +
-              targetFile,
-          );
+          if (typeof sourceArchive.filename === 'string') {
+            console.error(
+              'Related content from ' +
+                sourceArchive.filename +
+                ' not found: ' +
+                targetFile,
+            );
+          } else {
+            console.error('Related content not found: ' + targetFile);
+          }
         }
 
         if (assert) {

--- a/src/interfaces/iarchive.ts
+++ b/src/interfaces/iarchive.ts
@@ -1,5 +1,5 @@
 import ArchiveJszip from '../helper/archive/archive-jszip';
-import { AutomizerParams } from '../types/types';
+import { AutomizerFile, AutomizerParams } from '../types/types';
 import JSZip, { InputType } from 'jszip';
 import { XmlDocument } from '../types/xml-types';
 import ArchiveFs from '../helper/archive/archive-fs';
@@ -16,7 +16,7 @@ export type ArchivedFolderCallback = (file: ArchivedFile) => boolean;
 export type ArchiveInput = InputType;
 
 export default interface IArchive {
-  filename: string;
+  filename: AutomizerFile;
   read: (file: string, type) => Promise<string | Buffer>;
   write: (file: string, data: string | Buffer) => Promise<ArchiveType>;
   readXml: (file: string) => Promise<XmlDocument>;


### PR DESCRIPTION
This is related to #109, I noticed that the byte array was being logged to the console in the xml relationship helper, but the reason it was happening was concerning because `sourceArchive.filename` was typed as a string and I didn't know where else this might come up. The issue is the Archive base class accepted filename without a type, so while implementing #109 super was called which assigns the buffer to filename, then it's treated as a string elsewhere in code.

This PR explicitly types the Archive constructor arg as `AutomizerFile`, and I updated the places where filename is referenced to ensure it gets treated correctly depending on it's type. Note that the `ArchiveFS` is unchanged and still treats filename like a string as it won't be invoked with the buffer.