### PR TITLE
add remove chart title.  add helper function build tree

### DIFF
--- a/src/helper/modify-chart-helper.ts
+++ b/src/helper/modify-chart-helper.ts
@@ -22,22 +22,22 @@ export default class ModifyChartHelper {
    */
   static setChartData =
     (data: ChartData): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
-      const slots = [] as ChartSlot[];
-      data.series.forEach((series: ChartSeries, s: number) => {
-        slots.push({
-          index: s,
-          series: series,
-          targetCol: s + 1,
-          type: 'defaultSeries',
+      (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
+        const slots = [] as ChartSlot[];
+        data.series.forEach((series: ChartSeries, s: number) => {
+          slots.push({
+            index: s,
+            series: series,
+            targetCol: s + 1,
+            type: 'defaultSeries',
+          });
         });
-      });
 
-      new ModifyChart(chart, workbook, data, slots).modify();
+        new ModifyChart(chart, workbook, data, slots).modify();
 
-      // XmlHelper.dump(chart)
-      // XmlHelper.dump(workbook.table)
-    };
+        // XmlHelper.dump(chart)
+        // XmlHelper.dump(workbook.table)
+      };
 
   /**
    * Set chart data to modify vertical line charts.
@@ -45,32 +45,32 @@ export default class ModifyChartHelper {
    */
   static setChartVerticalLines =
     (data: ChartData): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
-      const slots = [] as ChartSlot[];
+      (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
+        const slots = [] as ChartSlot[];
 
-      slots.push({
-        label: `Y-Values`,
-        mapData: (point: number, category: ChartCategory) => category.y,
-        targetCol: 1,
-      });
-
-      data.series.forEach((series: ChartSeries, s: number) => {
         slots.push({
-          index: s,
-          series: series,
-          targetCol: s + 2,
-          type: 'xySeries',
+          label: `Y-Values`,
+          mapData: (point: number, category: ChartCategory) => category.y,
+          targetCol: 1,
         });
-      });
 
-      new ModifyChart(chart, workbook, data, slots).modify();
+        data.series.forEach((series: ChartSeries, s: number) => {
+          slots.push({
+            index: s,
+            series: series,
+            targetCol: s + 2,
+            type: 'xySeries',
+          });
+        });
 
-      // ModifyChartHelper.setAxisRange({
-      //   axisIndex: 0,
-      //   min: 0,
-      //   max: data.categories.length,
-      // })(element, chart);
-    };
+        new ModifyChart(chart, workbook, data, slots).modify();
+
+        // ModifyChartHelper.setAxisRange({
+        //   axisIndex: 0,
+        //   min: 0,
+        //   max: data.categories.length,
+        // })(element, chart);
+      };
 
   /**
    * Set chart data to modify scatter charts.
@@ -78,35 +78,35 @@ export default class ModifyChartHelper {
    */
   static setChartScatter =
     (data: ChartData): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
-      const slots = [] as ChartSlot[];
+      (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
+        const slots = [] as ChartSlot[];
 
-      data.series.forEach((series: ChartSeries, s: number) => {
-        const colId = s * 2;
-        slots.push({
-          index: s,
-          series: series,
-          targetCol: colId + 1,
-          type: 'customSeries',
-          tag: 'c:xVal',
-          mapData: (point: ChartPoint): number => point.x,
+        data.series.forEach((series: ChartSeries, s: number) => {
+          const colId = s * 2;
+          slots.push({
+            index: s,
+            series: series,
+            targetCol: colId + 1,
+            type: 'customSeries',
+            tag: 'c:xVal',
+            mapData: (point: ChartPoint): number => point.x,
+          });
+          slots.push({
+            label: `${series.label}-Y-Value`,
+            index: s,
+            series: series,
+            targetCol: colId + 2,
+            type: 'customSeries',
+            tag: 'c:yVal',
+            mapData: (point: ChartPoint): number => point.y,
+            isStrRef: false,
+          });
         });
-        slots.push({
-          label: `${series.label}-Y-Value`,
-          index: s,
-          series: series,
-          targetCol: colId + 2,
-          type: 'customSeries',
-          tag: 'c:yVal',
-          mapData: (point: ChartPoint): number => point.y,
-          isStrRef: false,
-        });
-      });
 
-      new ModifyChart(chart, workbook, data, slots).modify();
+        new ModifyChart(chart, workbook, data, slots).modify();
 
-      // XmlHelper.dump(chart)
-    };
+        // XmlHelper.dump(chart)
+      };
 
   /**
    * Set chart data to modify combo charts.
@@ -117,42 +117,42 @@ export default class ModifyChartHelper {
    */
   static setChartCombo =
     (data: ChartData): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
-      const slots = [] as ChartSlot[];
+      (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
+        const slots = [] as ChartSlot[];
 
-      slots.push({
-        index: 0,
-        series: data.series[0],
-        targetCol: 1,
-        type: 'defaultSeries',
-      });
+        slots.push({
+          index: 0,
+          series: data.series[0],
+          targetCol: 1,
+          type: 'defaultSeries',
+        });
 
-      slots.push({
-        index: 1,
-        label: `Y-Values`,
-        mapData: (point: number, category: ChartCategory) => category.y,
-        targetCol: 2,
-      });
+        slots.push({
+          index: 1,
+          label: `Y-Values`,
+          mapData: (point: number, category: ChartCategory) => category.y,
+          targetCol: 2,
+        });
 
-      data.series.forEach((series: ChartSeries, s: number) => {
-        if (s > 0)
-          slots.push({
-            index: s,
-            series: series,
-            targetCol: s + 2,
-            targetYCol: 2,
-            type: 'xySeries',
-          });
-      });
+        data.series.forEach((series: ChartSeries, s: number) => {
+          if (s > 0)
+            slots.push({
+              index: s,
+              series: series,
+              targetCol: s + 2,
+              targetYCol: 2,
+              type: 'xySeries',
+            });
+        });
 
-      new ModifyChart(chart, workbook, data, slots).modify();
+        new ModifyChart(chart, workbook, data, slots).modify();
 
-      ModifyChartHelper.setAxisRange({
-        axisIndex: 1,
-        min: 0,
-        max: data.categories.length,
-      })(element, chart);
-    };
+        ModifyChartHelper.setAxisRange({
+          axisIndex: 1,
+          min: 0,
+          max: data.categories.length,
+        })(element, chart);
+      };
 
   /**
    * Set chart data to modify bubble charts.
@@ -160,45 +160,45 @@ export default class ModifyChartHelper {
    */
   static setChartBubbles =
     (data: ChartData): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
-      const slots = [] as ChartSlot[];
+      (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
+        const slots = [] as ChartSlot[];
 
-      data.series.forEach((series: ChartSeries, s: number) => {
-        const colId = s * 3;
-        slots.push({
-          index: s,
-          series: series,
-          targetCol: colId + 1,
-          type: 'customSeries',
-          tag: 'c:xVal',
-          mapData: (point: ChartBubble): number => point.x,
+        data.series.forEach((series: ChartSeries, s: number) => {
+          const colId = s * 3;
+          slots.push({
+            index: s,
+            series: series,
+            targetCol: colId + 1,
+            type: 'customSeries',
+            tag: 'c:xVal',
+            mapData: (point: ChartBubble): number => point.x,
+          });
+          slots.push({
+            label: `${series.label}-Y-Value`,
+            index: s,
+            series: series,
+            targetCol: colId + 2,
+            type: 'customSeries',
+            tag: 'c:yVal',
+            mapData: (point: ChartBubble): number => point.y,
+            isStrRef: false,
+          });
+          slots.push({
+            label: `${series.label}-Size`,
+            index: s,
+            series: series,
+            targetCol: colId + 3,
+            type: 'customSeries',
+            tag: 'c:bubbleSize',
+            mapData: (point: ChartBubble): number => point.size,
+            isStrRef: false,
+          });
         });
-        slots.push({
-          label: `${series.label}-Y-Value`,
-          index: s,
-          series: series,
-          targetCol: colId + 2,
-          type: 'customSeries',
-          tag: 'c:yVal',
-          mapData: (point: ChartBubble): number => point.y,
-          isStrRef: false,
-        });
-        slots.push({
-          label: `${series.label}-Size`,
-          index: s,
-          series: series,
-          targetCol: colId + 3,
-          type: 'customSeries',
-          tag: 'c:bubbleSize',
-          mapData: (point: ChartBubble): number => point.size,
-          isStrRef: false,
-        });
-      });
 
-      new ModifyChart(chart, workbook, data, slots).modify();
+        new ModifyChart(chart, workbook, data, slots).modify();
 
-      // XmlHelper.dump(chart)
-    };
+        // XmlHelper.dump(chart)
+      };
 
   /**
    * Set chart data to modify extended chart types.
@@ -206,22 +206,22 @@ export default class ModifyChartHelper {
    */
   static setExtendedChartData =
     (data: ChartData): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
-      const slots = [] as ChartSlot[];
-      data.series.forEach((series: ChartSeries, s: number) => {
-        slots.push({
-          index: s,
-          series: series,
-          targetCol: s + 1,
-          type: 'extendedSeries',
+      (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
+        const slots = [] as ChartSlot[];
+        data.series.forEach((series: ChartSeries, s: number) => {
+          slots.push({
+            index: s,
+            series: series,
+            targetCol: s + 1,
+            type: 'extendedSeries',
+          });
         });
-      });
 
-      new ModifyChart(chart, workbook, data, slots).modifyExtended();
+        new ModifyChart(chart, workbook, data, slots).modifyExtended();
 
-      // XmlHelper.dump(chart);
-      // XmlHelper.dump(workbook.table)
-    };
+        // XmlHelper.dump(chart);
+        // XmlHelper.dump(workbook.table)
+      };
 
   /**
    * Read chart workbook data
@@ -229,33 +229,33 @@ export default class ModifyChartHelper {
    */
   static readWorkbookData =
     (data: any): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
-      const getSharedString = (index: number): string => {
-        return workbook.sharedStrings.getElementsByTagName('si').item(index)
-          ?.textContent;
-      };
+      (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
+        const getSharedString = (index: number): string => {
+          return workbook.sharedStrings.getElementsByTagName('si').item(index)
+            ?.textContent;
+        };
 
-      const parseCell = (cell: XmlElement): string | number => {
-        const type = cell.getAttribute('t');
-        const cellValue = cell.getElementsByTagName('v').item(0).textContent;
-        if (type === 's') {
-          return getSharedString(Number(cellValue));
-        } else {
-          return Number(cellValue);
+        const parseCell = (cell: XmlElement): string | number => {
+          const type = cell.getAttribute('t');
+          const cellValue = cell.getElementsByTagName('v').item(0).textContent;
+          if (type === 's') {
+            return getSharedString(Number(cellValue));
+          } else {
+            return Number(cellValue);
+          }
+        };
+
+        const rows = workbook.sheet.getElementsByTagName('row');
+        for (let r = 0; r < rows.length; r++) {
+          const row = rows.item(r);
+          const columns = row.getElementsByTagName('c');
+          const rowData = [];
+          for (let c = 0; c < columns.length; c++) {
+            rowData.push(parseCell(columns.item(c)));
+          }
+          data.push(rowData);
         }
       };
-
-      const rows = workbook.sheet.getElementsByTagName('row');
-      for (let r = 0; r < rows.length; r++) {
-        const row = rows.item(r);
-        const columns = row.getElementsByTagName('c');
-        const rowData = [];
-        for (let c = 0; c < columns.length; c++) {
-          rowData.push(parseCell(columns.item(c)));
-        }
-        data.push(rowData);
-      }
-    };
 
   /**
    * Read chart info
@@ -263,24 +263,24 @@ export default class ModifyChartHelper {
    */
   static readChartInfo =
     (info: any): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
-      const series = chart.getElementsByTagName('c:ser');
-      XmlHelper.modifyCollection(series, (tmpSeries: XmlElement, s: number) => {
-        const solidFill = tmpSeries.getElementsByTagName('a:solidFill').item(0);
-        if (!solidFill) {
-          return;
-        }
+      (element: XmlElement, chart?: XmlDocument, workbook?: Workbook): void => {
+        const series = chart.getElementsByTagName('c:ser');
+        XmlHelper.modifyCollection(series, (tmpSeries: XmlElement, s: number) => {
+          const solidFill = tmpSeries.getElementsByTagName('a:solidFill').item(0);
+          if (!solidFill) {
+            return;
+          }
 
-        const schemeClr = solidFill.getElementsByTagName('a:schemeClr').item(0);
-        const srgbClr = solidFill.getElementsByTagName('a:srgbClr').item(0);
-        const colorElement = schemeClr ? schemeClr : srgbClr;
-        info.series.push({
-          seriesId: s,
-          colorType: colorElement.tagName,
-          colorValue: colorElement.getAttribute('val'),
+          const schemeClr = solidFill.getElementsByTagName('a:schemeClr').item(0);
+          const srgbClr = solidFill.getElementsByTagName('a:srgbClr').item(0);
+          const colorElement = schemeClr ? schemeClr : srgbClr;
+          info.series.push({
+            seriesId: s,
+            colorType: colorElement.tagName,
+            colorValue: colorElement.getAttribute('val'),
+          });
         });
-      });
-    };
+      };
 
   /**
    * Set range and format for chart axis.
@@ -290,30 +290,30 @@ export default class ModifyChartHelper {
    */
   static setAxisRange =
     (range: ChartAxisRange): ChartModificationCallback =>
-    (element: XmlElement, chart: XmlDocument): void => {
-      const axis = chart.getElementsByTagName('c:valAx')[range.axisIndex || 0];
-      if (!axis) return;
+      (element: XmlElement, chart: XmlDocument): void => {
+        const axis = chart.getElementsByTagName('c:valAx')[range.axisIndex || 0];
+        if (!axis) return;
 
-      ModifyChartHelper.setAxisAttribute(axis, 'c:majorUnit', range.majorUnit);
-      ModifyChartHelper.setAxisAttribute(axis, 'c:minorUnit', range.minorUnit);
-      ModifyChartHelper.setAxisAttribute(
-        axis,
-        'c:numFmt',
-        range.formatCode,
-        'formatCode',
-      );
-      ModifyChartHelper.setAxisAttribute(
-        axis,
-        'c:numFmt',
-        range.sourceLinked,
-        'sourceLinked',
-      );
+        ModifyChartHelper.setAxisAttribute(axis, 'c:majorUnit', range.majorUnit);
+        ModifyChartHelper.setAxisAttribute(axis, 'c:minorUnit', range.minorUnit);
+        ModifyChartHelper.setAxisAttribute(
+          axis,
+          'c:numFmt',
+          range.formatCode,
+          'formatCode',
+        );
+        ModifyChartHelper.setAxisAttribute(
+          axis,
+          'c:numFmt',
+          range.sourceLinked,
+          'sourceLinked',
+        );
 
-      const scaling = axis.getElementsByTagName('c:scaling')[0];
+        const scaling = axis.getElementsByTagName('c:scaling')[0];
 
-      ModifyChartHelper.setAxisAttribute(scaling, 'c:min', range.min);
-      ModifyChartHelper.setAxisAttribute(scaling, 'c:max', range.max);
-    };
+        ModifyChartHelper.setAxisAttribute(scaling, 'c:min', range.min);
+        ModifyChartHelper.setAxisAttribute(scaling, 'c:max', range.max);
+      };
 
   static setAxisAttribute = (
     element: XmlElement,
@@ -340,14 +340,14 @@ export default class ModifyChartHelper {
    */
   static minimizeChartLegend =
     (): ChartModificationCallback =>
-    (element: XmlElement, chart: XmlDocument, workbook?: Workbook): void => {
-      this.setLegendPosition({
-        w: 0.0,
-        h: 0.0,
-        x: 0.0,
-        y: 0.0,
-      })(element, chart, workbook);
-    };
+      (element: XmlElement, chart: XmlDocument, workbook?: Workbook): void => {
+        this.setLegendPosition({
+          w: 0.0,
+          h: 0.0,
+          x: 0.0,
+          y: 0.0,
+        })(element, chart, workbook);
+      };
 
   /**
    * Completely remove a chart legend. Please notice: This will trigger
@@ -355,11 +355,11 @@ export default class ModifyChartHelper {
    */
   static removeChartLegend =
     (): ChartModificationCallback =>
-    (element: XmlElement, chart: XmlDocument): void => {
-      if (chart.getElementsByTagName('c:legend')) {
-        XmlHelper.remove(chart.getElementsByTagName('c:legend')[0]);
-      }
-    };
+      (element: XmlElement, chart: XmlDocument): void => {
+        if (chart.getElementsByTagName('c:legend')) {
+          XmlHelper.remove(chart.getElementsByTagName('c:legend')[0]);
+        }
+      };
 
   /**
    * Update the coordinates of a chart legend.
@@ -369,32 +369,32 @@ export default class ModifyChartHelper {
    */
   static setLegendPosition =
     (legendArea: ChartElementCoordinateShares): ChartModificationCallback =>
-    (element: XmlElement, chart: XmlDocument): void => {
-      const modifyXmlHelper = new ModifyXmlHelper(chart);
-      modifyXmlHelper.modify({
-        'c:legend': {
-          children: {
-            'c:manualLayout': {
-              children: {
-                'c:w': {
-                  modify: [ModifyXmlHelper.attribute('val', legendArea.w)],
-                },
-                'c:h': {
-                  modify: [ModifyXmlHelper.attribute('val', legendArea.h)],
-                },
-                'c:x': {
-                  modify: [ModifyXmlHelper.attribute('val', legendArea.x)],
-                },
-                'c:y': {
-                  modify: [ModifyXmlHelper.attribute('val', legendArea.y)],
+      (element: XmlElement, chart: XmlDocument): void => {
+        const modifyXmlHelper = new ModifyXmlHelper(chart);
+        modifyXmlHelper.modify({
+          'c:legend': {
+            children: {
+              'c:manualLayout': {
+                children: {
+                  'c:w': {
+                    modify: [ModifyXmlHelper.attribute('val', legendArea.w)],
+                  },
+                  'c:h': {
+                    modify: [ModifyXmlHelper.attribute('val', legendArea.h)],
+                  },
+                  'c:x': {
+                    modify: [ModifyXmlHelper.attribute('val', legendArea.x)],
+                  },
+                  'c:y': {
+                    modify: [ModifyXmlHelper.attribute('val', legendArea.y)],
+                  },
                 },
               },
             },
           },
-        },
-      });
-      // XmlHelper.dump(chart.getElementsByTagName('c:legendPos')[0]);
-    };
+        });
+        // XmlHelper.dump(chart.getElementsByTagName('c:legendPos')[0]);
+      };
 
   /**
    * Set the plot area coordinates of a chart.
@@ -415,79 +415,79 @@ export default class ModifyChartHelper {
    */
   static setPlotArea =
     (plotArea: ChartElementCoordinateShares): ChartModificationCallback =>
-    (element: XmlElement, chart?: XmlDocument): void => {
-      // Each chart has a separate chart xml file. It is required
-      // to alter everything that's "inside" the chart, e.g. data, legend,
-      // axis... and: plot area
+      (element: XmlElement, chart?: XmlDocument): void => {
+        // Each chart has a separate chart xml file. It is required
+        // to alter everything that's "inside" the chart, e.g. data, legend,
+        // axis... and: plot area
 
-      // ModifyXmlHelper class provides a lot of functions to access
-      // and edit xml elements.
-      const modifyXmlHelper = new ModifyXmlHelper(chart);
+        // ModifyXmlHelper class provides a lot of functions to access
+        // and edit xml elements.
+        const modifyXmlHelper = new ModifyXmlHelper(chart);
 
-      // We need to locate the required xml elements and target them
-      // with ModifyXmlHelper's help.
-      // We can therefore log the entire chart.xml to console:
-      // XmlHelper.dump(chart);
+        // We need to locate the required xml elements and target them
+        // with ModifyXmlHelper's help.
+        // We can therefore log the entire chart.xml to console:
+        // XmlHelper.dump(chart);
 
-      // There needs to be a 'c:manualLayout' element. This will only appear if
-      // a plot area was edited manually in ppt before. Recently fresh created
-      // charts will not have a manualLayout by default.
-      if (
-        !chart
-          .getElementsByTagName('c:plotArea')[0]
-          .getElementsByTagName('c:manualLayout')[0]
-      ) {
-        console.error("Can't update plot area. No c:manualLayout found.");
-        return;
-      }
+        // There needs to be a 'c:manualLayout' element. This will only appear if
+        // a plot area was edited manually in ppt before. Recently fresh created
+        // charts will not have a manualLayout by default.
+        if (
+          !chart
+            .getElementsByTagName('c:plotArea')[0]
+            .getElementsByTagName('c:manualLayout')[0]
+        ) {
+          console.error('Can\'t update plot area. No c:manualLayout found.');
+          return;
+        }
 
-      modifyXmlHelper.modify({
-        'c:plotArea': {
-          children: {
-            'c:manualLayout': {
-              children: {
-                'c:w': {
-                  // Finally, we attach ModifyCallbacks to all
-                  // matching elements
-                  modify: [
-                    ModifyXmlHelper.attribute('val', plotArea.w),
-                    // ...
-                  ],
-                },
-                'c:h': {
-                  modify: [ModifyXmlHelper.attribute('val', plotArea.h)],
-                },
-                'c:x': {
-                  modify: [ModifyXmlHelper.attribute('val', plotArea.x)],
-                },
-                'c:y': {
-                  modify: [ModifyXmlHelper.attribute('val', plotArea.y)],
+        modifyXmlHelper.modify({
+          'c:plotArea': {
+            children: {
+              'c:manualLayout': {
+                children: {
+                  'c:w': {
+                    // Finally, we attach ModifyCallbacks to all
+                    // matching elements
+                    modify: [
+                      ModifyXmlHelper.attribute('val', plotArea.w),
+                      // ...
+                    ],
+                  },
+                  'c:h': {
+                    modify: [ModifyXmlHelper.attribute('val', plotArea.h)],
+                  },
+                  'c:x': {
+                    modify: [ModifyXmlHelper.attribute('val', plotArea.x)],
+                  },
+                  'c:y': {
+                    modify: [ModifyXmlHelper.attribute('val', plotArea.y)],
+                  },
                 },
               },
             },
           },
-        },
-      });
+        });
 
-      // We can dump the target node and see if our modification
-      // took effect.
-      // XmlHelper.dump(
-      //   chart
-      //     .getElementsByTagName('c:plotArea')[0]
-      //     .getElementsByTagName('c:manualLayout')[0],
-      // );
+        // We can dump the target node and see if our modification
+        // took effect.
+        // XmlHelper.dump(
+        //   chart
+        //     .getElementsByTagName('c:plotArea')[0]
+        //     .getElementsByTagName('c:manualLayout')[0],
+        // );
 
-      // You can also take a look at element xml, which is a child node
-      // of current slide. It holds general shape properties, but no
-      // data or so.
-      // XmlHelper.dump(chart);
+        // You can also take a look at element xml, which is a child node
+        // of current slide. It holds general shape properties, but no
+        // data or so.
+        // XmlHelper.dump(chart);
 
-      // Rough ones might also want to look inside the linked workbook.
-      // It is located inside an extra xlsx file. We don't need this
-      // for now.
-      // XmlHelper.dump(workbook.table)
-      // XmlHelper.dump(workbook.sheet)
-    };
+        // Rough ones might also want to look inside the linked workbook.
+        // It is located inside an extra xlsx file. We don't need this
+        // for now.
+        // XmlHelper.dump(workbook.table)
+        // XmlHelper.dump(workbook.sheet)
+      };
 
   /**
    * Set a waterfall Total column to last
@@ -497,54 +497,121 @@ export default class ModifyChartHelper {
    */
   static setWaterFallColumnTotalToLast =
     (TotalColumnIDX?: number): ChartModificationCallback =>
-    (element: XmlElement, chart: XmlDocument): void => {
-      const plotArea = chart.getElementsByTagName('cx:plotArea')[0];
-      const subTotals = plotArea
-        ?.getElementsByTagName('cx:layoutPr')[0]
-        ?.getElementsByTagName('cx:subtotals')[0];
+      (element: XmlElement, chart: XmlDocument): void => {
+        const plotArea = chart.getElementsByTagName('cx:plotArea')[0];
+        const subTotals = plotArea
+          ?.getElementsByTagName('cx:layoutPr')[0]
+          ?.getElementsByTagName('cx:subtotals')[0];
 
-      if (subTotals) {
-        if (!TotalColumnIDX) {
-          const GetTotalPoints = chart
-            .getElementsByTagName('cx:chartData')[0]
-            ?.getElementsByTagName('cx:data')[0]
-            ?.getElementsByTagName('cx:strDim')[0]
-            ?.getElementsByTagName('cx:lvl')[0]
-            ?.getAttribute('ptCount');
-          if (GetTotalPoints) {
-            TotalColumnIDX = Number(GetTotalPoints) - 1;
+        if (subTotals) {
+          if (!TotalColumnIDX) {
+            const GetTotalPoints = chart
+              .getElementsByTagName('cx:chartData')[0]
+              ?.getElementsByTagName('cx:data')[0]
+              ?.getElementsByTagName('cx:strDim')[0]
+              ?.getElementsByTagName('cx:lvl')[0]
+              ?.getAttribute('ptCount');
+            if (GetTotalPoints) {
+              TotalColumnIDX = Number(GetTotalPoints) - 1;
+            }
+          }
+          if (TotalColumnIDX !== undefined) {
+            const stIndexes = Array.from(
+              subTotals.getElementsByTagName('cx:idx'),
+            );
+            stIndexes.forEach((sTValue, index) => {
+              ModifyXmlHelper.attribute(
+                'val',
+                TotalColumnIDX.toString(),
+              )(sTValue);
+              if (index > 0) {
+                subTotals.removeChild(sTValue);
+              }
+            });
           }
         }
-        if (TotalColumnIDX !== undefined) {
-          const stIndexes = Array.from(
-            subTotals.getElementsByTagName('cx:idx'),
-          );
-          stIndexes.forEach((sTValue, index) => {
-            ModifyXmlHelper.attribute(
-              'val',
-              TotalColumnIDX.toString(),
-            )(sTValue);
-            if (index > 0) {
-              subTotals.removeChild(sTValue);
-            }
-          });
-        }
-      }
+      };
+
+  /**
+   * Remove the title of a chart.
+   *
+   */
+  static removeChartTitle = (): ChartModificationCallback =>
+    (element: XmlElement, chart: XmlDocument): void => {
+      const modifyXmlHelper = new ModifyXmlHelper(chart);
+      modifyXmlHelper.createTree({
+        'c:chart': {
+          children: {
+            'c:title': {
+              remove: true,
+            },
+            'c:autoTitleDeleted': {
+              attributes: { 'val': '1' },
+            },
+          },
+        },
+      });
     };
 
   /**
-   * Set the title of a chart. This requires an already existing, manually edited chart title.
-    @param newTitle
+   }
+   * Set the title of a chart.
+   @param newTitle
    *
    */
-  static setChartTitle =
-    (newTitle: string): ChartModificationCallback =>
+  static setChartTitle = (newTitle: string): ChartModificationCallback =>
     (element: XmlElement, chart: XmlDocument): void => {
-      const chartTitle = chart.getElementsByTagName('c:title').item(0);
-      const chartTitleText = chartTitle?.getElementsByTagName('a:t').item(0);
-      if (chartTitleText) {
-        chartTitleText.textContent = newTitle;
-      }
+      const modifyXmlHelper = new ModifyXmlHelper(chart);
+      modifyXmlHelper.createTree({
+        'c:title': {
+          unique: true,
+          children: {
+            'c:tx': {
+              unique: true,
+              children: {
+                'c:rich': {
+                  unique: true,
+                  children: {
+                    'a:bodyPr': {
+                      attributes: {
+                        rot: '0',
+                        spcFirstLastPara: '1',
+                        vertOverflow: 'ellipsis',
+                        vert: 'horz',
+                        wrap: 'square',
+                        anchor: 'ctr',
+                        anchorCtr: '1',
+                      },
+                    },
+
+                    'a:lstStyle': { empty: true },
+                    'a:p': {
+                      clone: true,
+                      children: {
+                        'a:pPr': { clone: true },
+                        'a:r': {
+                          children: {
+                            'a:t': {
+                              slot: newTitle,
+                            },
+                          },
+                        },
+                        'a:endParaRPr': {
+                          unique: true,
+                          attributes: {
+                            lang: 'en-US',
+                            dirty: '0',
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
     };
 
   /**
@@ -554,82 +621,82 @@ export default class ModifyChartHelper {
    */
   static setDataLabelAttributes =
     (dataLabel: ChartDataLabelAttributes): ChartModificationCallback =>
-    (element: XmlElement, chart: XmlDocument): void => {
-      const modifyXmlHelper = new ModifyXmlHelper(chart);
-      const applyToSeries = dataLabel.applyToSeries
-        ? {
+      (element: XmlElement, chart: XmlDocument): void => {
+        const modifyXmlHelper = new ModifyXmlHelper(chart);
+        const applyToSeries = dataLabel.applyToSeries
+          ? {
             index: dataLabel.applyToSeries,
           }
-        : {
+          : {
             all: true,
           };
 
-      modifyXmlHelper.modify({
-        'c:ser': {
-          ...applyToSeries,
-          children: {
-            'c:dLbls': {
-              children: {
-                'c:dLblPos': {
-                  modify: [ModifyXmlHelper.attribute('val', dataLabel.dLblPos)],
-                },
-                'c:showLegendKey': {
-                  modify: [
-                    ModifyXmlHelper.booleanAttribute(
-                      'val',
-                      dataLabel.showLegendKey,
-                    ),
-                  ],
-                },
-                'c:showVal': {
-                  modify: [
-                    ModifyXmlHelper.booleanAttribute('val', dataLabel.showVal),
-                  ],
-                },
-                'c:showCatName': {
-                  modify: [
-                    ModifyXmlHelper.booleanAttribute(
-                      'val',
-                      dataLabel.showCatName,
-                    ),
-                  ],
-                },
-                'c:showSerName': {
-                  modify: [
-                    ModifyXmlHelper.booleanAttribute(
-                      'val',
-                      dataLabel.showSerName,
-                    ),
-                  ],
-                },
-                'c:showPercent': {
-                  modify: [
-                    ModifyXmlHelper.booleanAttribute(
-                      'val',
-                      dataLabel.showPercent,
-                    ),
-                  ],
-                },
-                'c:showBubbleSize': {
-                  modify: [
-                    ModifyXmlHelper.booleanAttribute(
-                      'val',
-                      dataLabel.showBubbleSize,
-                    ),
-                  ],
-                },
-                'c:showLeaderLines': {
-                  modify: [
-                    ModifyXmlHelper.booleanAttribute(
-                      'val',
-                      dataLabel.showLeaderLines,
-                    ),
-                  ],
+        modifyXmlHelper.modify({
+          'c:ser': {
+            ...applyToSeries,
+            children: {
+              'c:dLbls': {
+                children: {
+                  'c:dLblPos': {
+                    modify: [ModifyXmlHelper.attribute('val', dataLabel.dLblPos)],
+                  },
+                  'c:showLegendKey': {
+                    modify: [
+                      ModifyXmlHelper.booleanAttribute(
+                        'val',
+                        dataLabel.showLegendKey,
+                      ),
+                    ],
+                  },
+                  'c:showVal': {
+                    modify: [
+                      ModifyXmlHelper.booleanAttribute('val', dataLabel.showVal),
+                    ],
+                  },
+                  'c:showCatName': {
+                    modify: [
+                      ModifyXmlHelper.booleanAttribute(
+                        'val',
+                        dataLabel.showCatName,
+                      ),
+                    ],
+                  },
+                  'c:showSerName': {
+                    modify: [
+                      ModifyXmlHelper.booleanAttribute(
+                        'val',
+                        dataLabel.showSerName,
+                      ),
+                    ],
+                  },
+                  'c:showPercent': {
+                    modify: [
+                      ModifyXmlHelper.booleanAttribute(
+                        'val',
+                        dataLabel.showPercent,
+                      ),
+                    ],
+                  },
+                  'c:showBubbleSize': {
+                    modify: [
+                      ModifyXmlHelper.booleanAttribute(
+                        'val',
+                        dataLabel.showBubbleSize,
+                      ),
+                    ],
+                  },
+                  'c:showLeaderLines': {
+                    modify: [
+                      ModifyXmlHelper.booleanAttribute(
+                        'val',
+                        dataLabel.showLeaderLines,
+                      ),
+                    ],
+                  },
                 },
               },
             },
           },
-        },
-      });
-    };
+        });
+      };
 }

--- a/src/helper/modify-chart-helper.ts
+++ b/src/helper/modify-chart-helper.ts
@@ -563,44 +563,48 @@ export default class ModifyChartHelper {
     (element: XmlElement, chart: XmlDocument): void => {
       const modifyXmlHelper = new ModifyXmlHelper(chart);
       modifyXmlHelper.createTree({
-        'c:title': {
-          unique: true,
+        'c:chart': {
           children: {
-            'c:tx': {
+            'c:title': {
               unique: true,
               children: {
-                'c:rich': {
+                'c:tx': {
                   unique: true,
                   children: {
-                    'a:bodyPr': {
-                      attributes: {
-                        rot: '0',
-                        spcFirstLastPara: '1',
-                        vertOverflow: 'ellipsis',
-                        vert: 'horz',
-                        wrap: 'square',
-                        anchor: 'ctr',
-                        anchorCtr: '1',
-                      },
-                    },
-
-                    'a:lstStyle': { empty: true },
-                    'a:p': {
-                      clone: true,
+                    'c:rich': {
+                      unique: true,
                       children: {
-                        'a:pPr': { clone: true },
-                        'a:r': {
-                          children: {
-                            'a:t': {
-                              slot: newTitle,
-                            },
+                        'a:bodyPr': {
+                          attributes: {
+                            rot: '0',
+                            spcFirstLastPara: '1',
+                            vertOverflow: 'ellipsis',
+                            vert: 'horz',
+                            wrap: 'square',
+                            anchor: 'ctr',
+                            anchorCtr: '1',
                           },
                         },
-                        'a:endParaRPr': {
-                          unique: true,
-                          attributes: {
-                            lang: 'en-US',
-                            dirty: '0',
+
+                        'a:lstStyle': { empty: true },
+                        'a:p': {
+                          clone: true,
+                          children: {
+                            'a:pPr': { clone: true },
+                            'a:r': {
+                              children: {
+                                'a:t': {
+                                  slot: newTitle,
+                                },
+                              },
+                            },
+                            'a:endParaRPr': {
+                              unique: true,
+                              attributes: {
+                                lang: 'en-US',
+                                dirty: '0',
+                              },
+                            },
                           },
                         },
                       },
@@ -608,6 +612,9 @@ export default class ModifyChartHelper {
                   },
                 },
               },
+            },
+            'c:autoTitleDeleted': {
+              attributes: { 'val': '0' },
             },
           },
         },

--- a/src/helper/modify-xml-helper.ts
+++ b/src/helper/modify-xml-helper.ts
@@ -1,4 +1,4 @@
-import { Modification, ModificationTags } from '../types/modify-types';
+import { CreateTreeAttributes, CreateTreeStructure, Modification, ModificationTags } from '../types/modify-types';
 import StringIdGenerator from './cell-id-helper';
 import { GeneralHelper } from './general-helper';
 import { XmlHelper } from './xml-helper';
@@ -7,11 +7,13 @@ import { XmlDocument, XmlElement } from '../types/xml-types';
 
 export default class ModifyXmlHelper {
   root: XmlDocument | XmlElement;
+  treeStart: XmlDocument | XmlElement;
   templates: { [key: string]: XmlElement };
 
   constructor(root: XmlDocument | XmlElement) {
     this.root = root;
     this.templates = {};
+
   }
 
   modify(tags: ModificationTags, root?: XmlDocument | XmlElement): void {
@@ -136,6 +138,144 @@ export default class ModifyXmlHelper {
         return true;
     }
     return false;
+  }
+
+  createTree(structure: CreateTreeStructure, root?: XmlElement): XmlElement {
+    root = root || this.root as XmlElement;
+    this.treeStart = root;
+    this.buildTree(structure, root);
+    this.reorderChildren(root, structure);
+
+    return root;
+  }
+
+  private buildTree(structure: CreateTreeStructure, currentParent: XmlElement): XmlElement {
+    for (const tag in structure) {
+
+      if (structure[tag].remove) {
+        const elements = currentParent.getElementsByTagName(tag);
+        for (let i = elements.length - 1; i >= 0; i--) {
+          currentParent.removeChild(elements[i]);
+        }
+        continue;
+      }
+
+      let element: XmlElement;
+      if (structure[tag].unique) {
+        element = this.ensureUniqueElement(currentParent, tag);
+      } else if (structure[tag].clone) {
+        element = this.cloneOrBuildElement(tag, currentParent, structure[tag].attributes);
+      } else {
+        element = currentParent.getElementsByTagName(tag)[0] || this.buildElement(tag, structure[tag].attributes);
+        if (!currentParent.getElementsByTagName(tag)[0]) {
+          currentParent.appendChild(element);
+        }
+      }
+
+      if (structure[tag].attributes) {
+        this.addAttributes(element, structure[tag].attributes);
+      }
+      if (structure[tag].removeChildren) {
+        while (element.firstChild) {
+          element.removeChild(element.firstChild);
+        }
+      }
+
+      if (structure[tag].empty) {
+        continue;
+      }
+
+      if (structure[tag].slot !== undefined) {
+        element.textContent = this.setTextElement(String(structure[tag].slot));
+      }
+
+      if (structure[tag].children) {
+        this.buildTree(structure[tag].children, element);
+      }
+    }
+    return currentParent;
+  }
+
+  private reorderChildren(parent: XmlElement, structure: CreateTreeStructure): void {
+    for (const tag in structure) {
+      const elements = Array.from(parent.getElementsByTagName(tag));
+      if (elements.length > 0) {
+        const element = elements[0];
+
+        const childTags = Object.keys(structure[tag].children || {});
+
+        childTags.forEach(childTag => {
+          const children = Array.from(element.getElementsByTagName(childTag));
+          children.forEach(child => element.appendChild(child));
+        });
+
+        this.reorderChildren(element, structure[tag].children || {});
+      }
+    }
+  }
+
+  private cloneOrBuildElement(tag: string, currentParent: XmlElement, attributes?: CreateTreeAttributes): XmlElement {
+    let element = currentParent.getElementsByTagName(tag)[0];
+    if (!element) {
+      element = this.cloneElement(tag) || this.buildElement(tag, attributes);
+      currentParent.appendChild(element);
+    }
+    return element;
+  }
+
+  private cloneElement(tag: string): XmlElement | null {
+    const elementToClone = this.treeStart.getElementsByTagName(tag)[0];
+    if (elementToClone) {
+      return elementToClone.cloneNode(true) as XmlElement;
+    }
+    return null;
+  }
+
+  private ensureUniqueElement(parent: XmlElement, tag: string): XmlElement {
+    let element = parent.getElementsByTagName(tag)[0];
+    if (!element) {
+      element = this.buildElement(tag);
+      parent.appendChild(element);
+    } else {
+      this.removeAdditionalElements(parent, tag, 0);
+    }
+    return element;
+  }
+
+  addAttributes(element: XmlElement, attributes: CreateTreeAttributes): void {
+    for (const [attr, value] of Object.entries(attributes)) {
+      if (typeof value === 'string' || typeof value === 'number') {
+        element.setAttribute(attr, String(value));
+      }
+    }
+  }
+
+  setTextElement(text: string): string {
+    if (typeof text === 'string' || typeof text === 'number') {
+      if (text.length > 0) {
+        return text;
+      }
+    }
+    return ' ';
+  }
+
+  removeAdditionalElements(parent: XmlElement, tag: string, startIndex: number): void {
+    const elements = parent.getElementsByTagName(tag);
+    for (let i = elements.length - 1; i > startIndex; i--) {
+      parent.removeChild(elements[i]);
+    }
+  }
+
+  private buildElement(tag: string, attributes?: CreateTreeAttributes): XmlElement {
+    const element = this.root.ownerDocument.createElement(tag);
+    if (attributes) {
+      for (const [attr, value] of Object.entries(attributes)) {
+        if (typeof value === 'string' || typeof value === 'number') {
+          element.setAttribute(attr, String(value));
+        }
+      }
+    }
+    return element;
   }
 
   static getText = (element: XmlElement): string => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,7 @@ const removeChartLegend = ModifyChartHelper.removeChartLegend;
 const minimizeChartLegend = ModifyChartHelper.minimizeChartLegend;
 const setWaterFallColumnTotalToLast =
   ModifyChartHelper.setWaterFallColumnTotalToLast;
+const removeChartTitle = ModifyChartHelper.removeChartTitle;
 const setChartTitle = ModifyChartHelper.setChartTitle;
 const setDataLabelAttributes = ModifyChartHelper.setDataLabelAttributes;
 const readWorkbookData = ModifyChartHelper.readWorkbookData;
@@ -145,6 +146,7 @@ export const modify = {
   removeChartLegend,
   minimizeChartLegend,
   setWaterFallColumnTotalToLast,
+  removeChartTitle,
   setChartTitle,
   setDataLabelAttributes,
 };

--- a/src/types/modify-types.ts
+++ b/src/types/modify-types.ts
@@ -69,3 +69,21 @@ export type ReplaceTextOptions = {
   openingTag: string;
   closingTag: string;
 };
+
+export type CreateTreeAttributes = {
+  [key: string]: string | number
+};
+
+export type CreateTreeNode = {
+  attributes?: CreateTreeAttributes;
+  children?: CreateTreeStructure;
+  clone?: boolean,
+  unique?: boolean,
+  remove?: boolean,
+  slot?: string | number;
+  [key: string]: any;
+};
+
+export type CreateTreeStructure = {
+  [tag: string]: CreateTreeNode;
+};


### PR DESCRIPTION
-Improved setChartTitle function. no longer need an existing title
-Added remove title function

Added a new function to traverse the XML tree. this is inspired by your modify function in the library.  it will allow you to create elements and set attributes or remove attributes.  the "clone" property will look in the dom parent first for an element to clone so we can match styles 

example how i used it for the removeChartTitle

 modifyXmlHelper.createTree({
        'c:chart': {
          children: {
            'c:title': {
              remove: true,
            },
            'c:autoTitleDeleted': {
              attributes: { 'val': '1' },
            },
          },
        },
      });