### PR TITLE
Added support for setRelationTargetCover using aspect detection

### DIFF
--- a/src/helper/compute-src-rect.ts
+++ b/src/helper/compute-src-rect.ts
@@ -1,0 +1,54 @@
+type SrcRect = { l?: number; t?: number; r?: number; b?: number }; // thousandths-of-percent
+const K = 100000;
+
+// Convert the source rectangle to fractions of the image width and height for easier calculation
+function toFractions(src: SrcRect): { l: number; t: number; r: number; b: number } {
+  return {
+    l: (src.l ?? 0) / K,
+    t: (src.t ?? 0) / K,
+    r: (src.r ?? 0) / K,
+    b: (src.b ?? 0) / K,
+  };
+}
+
+// Infer the container aspect ratio from the original image dimensions and the current source rectangle
+export function inferContainerAr(
+  oldImageWidth: number,
+  oldImageHeight: number,
+  currentSrcRect: SrcRect // read from the slide; missing attrs mean 0
+): number {
+  const { l, t, r, b } = toFractions(currentSrcRect);
+  const wf = 1 - (l + r);
+  const hf = 1 - (t + b);
+  const oldAr = oldImageWidth / oldImageHeight;
+  return oldAr * (wf / hf || 1); // guard vs hf=0
+}
+
+// Compute the new source rectangle for a new image based on the container aspect ratio and the new image dimensions
+export function computeSrcRectForNewImage(
+  containerAr: number,
+  newImageWidth: number,
+  newImageHeight: number
+): SrcRect {
+  const newAr = newImageWidth / newImageHeight;
+  if (!isFinite(containerAr) || !isFinite(newAr) || containerAr <= 0 || newAr <= 0) {
+    return { l: 0, t: 0, r: 0, b: 0 };
+  }
+
+  if (newAr > containerAr) {
+    // new image is wider than the container -> crop width
+    const visibleW = containerAr / newAr;
+    const crop = Math.max(0, Math.min(0.5, (1 - visibleW) / 2));
+    const cropHorizontal = Math.round(crop * K);
+    return { l: cropHorizontal, r: cropHorizontal, t: 0, b: 0 };
+  } else if (newAr < containerAr) {
+    // new image is taller than the container -> crop height
+    const visibleH = newAr / containerAr;
+    const crop = Math.max(0, Math.min(0.5, (1 - visibleH) / 2));
+    const cropVertical = Math.round(crop * K);
+    return { l: 0, r: 0, t: cropVertical, b: cropVertical };
+  } else {
+    // equal AR -> no crop needed
+    return { l: 0, t: 0, r: 0, b: 0 };
+  }
+}

--- a/src/helper/modify-image-helper.ts
+++ b/src/helper/modify-image-helper.ts
@@ -1,6 +1,10 @@
 import { XmlElement } from '../types/xml-types';
 import { ImageStyle } from '../types/modify-types';
 import slugify from 'slugify';
+import {imageSize } from 'image-size';
+import fs from 'fs';
+import { IPresentationProps } from '../interfaces/ipresentation-props';
+import { computeSrcRectForNewImage, inferContainerAr } from './compute-src-rect';
 
 export default class ModifyImageHelper {
   /**
@@ -13,6 +17,94 @@ export default class ModifyImageHelper {
       arg1.setAttribute('Target', '../media/' + slugify(filename));
     };
   };
+
+  /**
+   * Update the "Target" attribute of a created image relation.
+   * This will change the image itself. Load images with Automizer.loadMedia
+   * This will also auto-crop the image to the new width and height,
+   * based on the container aspect ratio, derived from the original image
+   * and using the new image width and height based on the files loaded into
+   * the presentation media folder using .loadMedia()
+   * @param filename name of target image in root template media folder.
+   * @param pres presentation properties (to access the root template archive)
+   * @param newImageWidth width of the new image
+   * @param newImageHeight height of the new image
+   */
+  static setRelationTargetCover = (
+    filename: string,
+    pres: IPresentationProps,
+  ) => {
+    return async (element: XmlElement, arg1: XmlElement): Promise<void> => {
+
+      const newTarget = '../media/' + slugify(filename);
+      const originalTarget = arg1.getAttribute('Target');
+      const originalTargetPath = originalTarget.replace('../', 'ppt/');
+      const originalImageDimensions = { width: 100, height: 100 };
+      const newImageDimensions = { width: 100, height: 100 };
+
+
+      // Get the new image dimensions, using the rootTemplate mediafiles array,
+      // since we have it loaded into the presentation media folder using .loadMedia()
+      // If we don't find the media file, we warn, but continue
+      try {
+        const mediaFile = pres.rootTemplate.mediaFiles.find(file => file.file === filename);
+        if(!mediaFile) {
+          throw new Error("Media file not found in template archive in path: " + filename);
+        }
+        const buffer = fs.readFileSync(mediaFile.filepath);
+        const _dimensions = imageSize(buffer);
+        newImageDimensions.width = _dimensions.width;
+        newImageDimensions.height = _dimensions.height;
+      } catch (error) {
+        console.warn("Couldn't find media file in template archive in path.");
+      }
+      
+      // Find the original image dimensions using the original target path from the original slide
+      // using the rootTemplate archive file system and get the image dimensions.
+      // If we don't find the original image, we warn, but continue
+      // If we find the original image, we get the image dimensions and use this to reverse calculate
+      // the aspect ratio and then use the new image dimensions to calculate and set the new crop on srcRect.
+      // This results in the image being cropped in the image container to match the aspect ratio of the new image.
+      try {
+        if(pres.rootTemplate.archive.fileExists(originalTargetPath)) {
+          const originalImage = await pres.rootTemplate.archive.read(originalTargetPath, "nodebuffer");
+          const _dimensions = imageSize(originalImage);
+          originalImageDimensions.width = _dimensions.width;
+          originalImageDimensions.height = _dimensions.height;
+        } else {
+          throw new Error("Original image not found from template archive in path: " + originalTargetPath);
+        }
+  
+        const srcRect = element.getElementsByTagName('a:srcRect')[0];
+        const srcRectLeft = srcRect.getAttribute('l');
+        const srcRectTop = srcRect.getAttribute('t');
+        const srcRectRight = srcRect.getAttribute('r');
+        const srcRectBottom = srcRect.getAttribute('b');
+  
+        const currentSrcRect = {
+          l: srcRectLeft ? Number(srcRectLeft) : 0,
+          t: srcRectTop ? Number(srcRectTop) : 0,
+          r: srcRectRight ? Number(srcRectRight) : 0,
+          b: srcRectBottom ? Number(srcRectBottom) : 0,
+        }
+  
+        const containerAr = inferContainerAr(originalImageDimensions.width, originalImageDimensions.height, currentSrcRect);
+        
+        const newSrcRect = computeSrcRectForNewImage(containerAr, newImageDimensions.width, newImageDimensions.height);
+        
+        srcRect.setAttribute('l', String(newSrcRect.l));
+        srcRect.setAttribute('t', String(newSrcRect.t));
+        srcRect.setAttribute('r', String(newSrcRect.r));
+        srcRect.setAttribute('b', String(newSrcRect.b));
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.warn("Skipped setting relation target cropped due to an error: " + errorMessage);
+      }
+      
+      arg1.setAttribute('Target', newTarget);
+
+    };
+  }
 
   /*
     Update an existing duotone image overlay element (WIP)


### PR DESCRIPTION
Implemented a new feature `setRelationTargetCover` in `ModifyImageHelper` that takes `filename` and `pres` as args and handles updating the relation Target while also updating the crop of the image in the `<a:srcRect>` with proper left, right, top, bottom values to ensure new image is cropped based on the proper aspect ratio of the image container and the new target image.

What it does:
1. Gets the dimensions of the new target image from the presentation `rootTemplate.mediaFiles`
2. Gets the dimensions of the old target image from the presentation `rootTemplate.archive` 
3. Calculates an inferred image container aspect ratio based on current crop values and aspect of original image
4. Recalculates new crop values based on new target image and inferred image container aspect ratio
5. Updates and sets proper left/right/top/bottom crop based on whether horizontal or vertical crop is necessary