### PR TITLE
bug not awaiting applyCallbacks

### DIFF
--- a/src/classes/shape.ts
+++ b/src/classes/shape.ts
@@ -234,20 +234,20 @@ export class Shape {
       .setAttribute(this.relAttribute, this.createdRid);
   }
 
-  applyCallbacks(
+  async applyCallbacks(
     callbacks: ShapeModificationCallback[],
     element: XmlElement,
     relation?: XmlElement,
-  ): void {
-    callbacks.forEach((callback) => {
+  ): Promise<void> {
+    for (const callback of callbacks) {
       if (typeof callback === 'function') {
         try {
-          callback(element, relation);
+          await callback(element, relation);
         } catch (e) {
           console.warn(e);
         }
       }
-    });
+    }
   }
 
   applyChartCallbacks(

--- a/src/shapes/diagram.ts
+++ b/src/shapes/diagram.ts
@@ -125,7 +125,7 @@ export class Diagram extends Shape {
 
   async clone(): Promise<void> {
     await this.setTargetElement();
-    this.applyCallbacks(this.callbacks, this.targetElement);
+    await this.applyCallbacks(this.callbacks, this.targetElement);
   }
 
   async updateRelIds() {

--- a/src/shapes/generic.ts
+++ b/src/shapes/generic.ts
@@ -65,7 +65,7 @@ export class GenericShape extends Shape {
 
     // Pass both the element and the relation to applyCallbacks
     // Use the documentElement property to get the root element of the XML document
-    this.applyCallbacks(this.callbacks, this.targetElement, slideRelXml.documentElement as XmlElement);
+    await this.applyCallbacks(this.callbacks, this.targetElement, slideRelXml.documentElement as XmlElement);
   }
 
   /**

--- a/src/shapes/hyperlink.ts
+++ b/src/shapes/hyperlink.ts
@@ -46,7 +46,7 @@ export class Hyperlink extends Shape {
 
     // Pass both the element and the relation to applyCallbacks
     // Use the documentElement property to get the root element of the XML document
-    this.applyCallbacks(this.callbacks, this.targetElement, slideRelXml);
+    await this.applyCallbacks(this.callbacks, this.targetElement, slideRelXml);
 
     return this;
   }

--- a/src/shapes/image.ts
+++ b/src/shapes/image.ts
@@ -82,7 +82,7 @@ export class Image extends Shape implements IImage {
     await this.updateTargetElementRelId();
     await this.processImageRelations(targetTemplate, targetSlideNumber);
 
-    this.applyImageCallbacks();
+    await this.applyImageCallbacks();
 
     await this.replaceIntoSlideTree();
 
@@ -99,7 +99,7 @@ export class Image extends Shape implements IImage {
     await this.updateTargetElementRelId();
     await this.processImageRelations(targetTemplate, targetSlideNumber);
 
-    this.applyImageCallbacks();
+    await this.applyImageCallbacks();
 
     await this.appendToSlideTree();
 
@@ -208,8 +208,8 @@ export class Image extends Shape implements IImage {
    * Third argument this.createdRelation is necessery to directly
    * manipulate relation Target and change the image.
    */
-  applyImageCallbacks() {
-    this.applyCallbacks(
+  async applyImageCallbacks(): Promise<void> {
+    await this.applyCallbacks(
       this.callbacks,
       this.targetElement,
       this.createdRelation,

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -31,7 +31,7 @@ export type ShapeModificationCallback = (
   element: XmlElement,
   relation?: XmlElement,
   info?: ElementInfo
-) => void;
+) => void | Promise<void>;
 export type ChartModificationCallback = (
   element: XmlElement,
   chart?: XmlDocument,


### PR DESCRIPTION
Previously the applyCallbacks ran without awaiting, so e.g. setRelationTargetCover could finish after the slide was already written, leaving the larger placeholder image in place instead of the replacement.
This issue can be reproduced when setting a bigger image (file size) as a placeholder image in an PowerPoint image placeholder element and then trying to replace it with any other image. The image will not be replaced.
By awaiting applyCallbacks this functions properly now.