### PR TITLE
fix(chart): add `<c:invertIfNegative>` to `<c:dPt>` with default `val="0"`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@ semver, with the pre-1.0 convention that **breaking changes bump the minor**.
   styles on template-less points now materialize as a bare `<a:ln>` in schema
   position instead of silently relying on the fabricated default (per-point
   *marker* styling remains modify-if-present).
+- A created `<c:dPt>` now pins `<c:invertIfNegative val="0"/>`. OOXML
+  defaults the absent element to *true*, so PowerPoint inverted the fill of
+  negative-value **bar** points — rendering them white with a border and
+  silently overriding the very fill the point was styled for. The pre-0.9.0
+  code never hit this because it cloned the template's existing data point
+  (inheriting its `invertIfNegative`); the empty-shell creation lost the flag.
+  LibreOffice ignores `invertIfNegative`, which is why the tier-3 golden
+  decks could not catch it.
 - Documentation only — examples that documented APIs which never existed:
   `replaceText` has no regex/whole-word/case options (its options are the
   `openingTag`/`closingTag` tag delimiters, default `{{`/`}}`);

--- a/__tests__/modify-chart-point-styles-line.test.ts
+++ b/__tests__/modify-chart-point-styles-line.test.ts
@@ -36,6 +36,13 @@ const dataPointsOf = (ser: XmlElement) =>
   Array.from(ser.getElementsByTagName('c:dPt')).map((dPt) => ({
     idx: dPt.getElementsByTagName('c:idx')[0].getAttribute('val'),
     color: dPt.getElementsByTagName('a:srgbClr')[0]?.getAttribute('val'),
+    // OOXML defaults an absent c:invertIfNegative to *true*: PowerPoint then
+    // inverts the fill of negative-value bars (white with a border),
+    // overriding the styled color — and LibreOffice ignores the flag, so the
+    // tier-3 golden decks cannot see it. A created c:dPt must pin it to 0.
+    invertIfNegative: dPt
+      .getElementsByTagName('c:invertIfNegative')[0]
+      ?.getAttribute('val'),
   }));
 
 test('per-point styles on a line chart create no c:dPt beyond the explicitly styled points', async () => {
@@ -121,7 +128,9 @@ test('per-point styles on a line chart create no c:dPt beyond the explicitly sty
 
   // Only the real style at category 1 materializes; the pseudo-styles at
   // categories 2 and 3 produce no c:dPt — not even an empty shell.
-  expect(dataPointsOf(series[0])).toEqual([{ idx: '1', color: 'FF0000' }]);
+  expect(dataPointsOf(series[0])).toEqual([
+    { idx: '1', color: 'FF0000', invertIfNegative: '0' },
+  ]);
   expect(dataPointsOf(series[1])).toEqual([]);
   expect(dataPointsOf(series[2])).toEqual([]);
 

--- a/src/helper/xml-elements.ts
+++ b/src/helper/xml-elements.ts
@@ -417,13 +417,21 @@ export default class XmlElements {
   }
 
   /**
-   * A minimal <c:dPt> shell: `c:idx` plus `c:bubble3D` (which PowerPoint
-   * always writes) and nothing else. A data point carries no formatting the
-   * caller did not ask for — modifications create `c:spPr` etc. on demand.
+   * A minimal <c:dPt> shell: `c:idx`, `c:invertIfNegative` and `c:bubble3D`
+   * (which PowerPoint always writes) and nothing else. A data point carries
+   * no formatting the caller did not ask for — modifications create `c:spPr`
+   * etc. on demand. `c:invertIfNegative` must be written explicitly: OOXML
+   * defaults the absent element to *true*, which makes PowerPoint invert the
+   * fill of negative-value bars (white with a border) — silently overriding
+   * the very fill the caller styled the point for. LibreOffice ignores the
+   * flag, so pixel-based golden decks cannot catch this.
    */
   buildDataPoint(): XmlElement {
     const dPt = this.document.createElement('c:dPt');
     dPt.appendChild(this.idx());
+    const invertIfNegative = this.document.createElement('c:invertIfNegative');
+    invertIfNegative.setAttribute('val', '0');
+    dPt.appendChild(invertIfNegative);
     const bubble3D = this.document.createElement('c:bubble3D');
     bubble3D.setAttribute('val', '0');
     dPt.appendChild(bubble3D);


### PR DESCRIPTION
Prevents PowerPoint from inverting the fill of negative-value bars, which silently overrides custom styling.